### PR TITLE
fix memory adapter method to always return bool

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    this_feature (0.5.0)
-    this_feature-adapters-flipper (0.5.0)
+    this_feature (0.5.3)
+    this_feature-adapters-flipper (0.5.3)
       flipper (~> 0.16)
       flipper-active_record (~> 0.16)
       this_feature
-    this_feature-adapters-split_io (0.5.0)
+    this_feature-adapters-split_io (0.5.3)
       splitclient-rb
       this_feature
 

--- a/lib/this_feature/adapters/memory.rb
+++ b/lib/this_feature/adapters/memory.rb
@@ -30,7 +30,7 @@ class ThisFeature
       def off?(flag_name, context: nil, data: {})
         on_result = on?(flag_name, context: context)
 
-        return if on_result.nil?
+        return true if on_result.nil?
 
         !on_result
       end

--- a/lib/this_feature/adapters/memory.rb
+++ b/lib/this_feature/adapters/memory.rb
@@ -28,11 +28,7 @@ class ThisFeature
       end
 
       def off?(flag_name, context: nil, data: {})
-        on_result = on?(flag_name, context: context)
-
-        return true if on_result.nil?
-
-        !on_result
+        !on?(flag_name, context: context)
       end
 
       def on!(flag_name, context: nil, data: {})

--- a/lib/this_feature/adapters/memory.rb
+++ b/lib/this_feature/adapters/memory.rb
@@ -28,7 +28,7 @@ class ThisFeature
       end
 
       def off?(flag_name, context: nil, data: {})
-        !on?(flag_name, context: context)
+        !on?(flag_name, context: context, data: data)
       end
 
       def on!(flag_name, context: nil, data: {})

--- a/lib/this_feature/adapters/memory.rb
+++ b/lib/this_feature/adapters/memory.rb
@@ -15,7 +15,7 @@ class ThisFeature
       end
 
       def on?(flag_name, context: nil, data: {})
-        return unless present?(flag_name)
+        return false unless present?(flag_name)
 
         flag_data = storage[flag_name]
 

--- a/lib/this_feature/version.rb
+++ b/lib/this_feature/version.rb
@@ -1,3 +1,3 @@
 class ThisFeature
-  VERSION = "0.5.2"
+  VERSION = "0.5.3"
 end

--- a/spec/this_feature/adapters/memory_adapter_spec.rb
+++ b/spec/this_feature/adapters/memory_adapter_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe ThisFeature::Adapters::Memory do
     subject(:on?) { flag.on? }
 
     context "looking up a flag that doesnt exist" do
-      it { is_expected.to be_nil }
+      it { is_expected.to be(false) }
     end
 
     context "looking up a flag that is set to on" do
@@ -79,7 +79,7 @@ RSpec.describe ThisFeature::Adapters::Memory do
 
     context "looking up a flag that doesnt exist" do
       it "returns nil" do
-        expect(subject).to be_nil
+        expect(subject).to be(true)
       end
     end
 


### PR DESCRIPTION
`on?` will return nil if if the key is not present.

We want it to return false in that case.