### PR TITLE
Rename constant for empty context

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    this_feature (0.7.0)
-    this_feature-adapters-flipper (0.7.0)
+    this_feature (0.7.1)
+    this_feature-adapters-flipper (0.7.1)
       flipper (~> 0.16)
       flipper-active_record (~> 0.16)
       this_feature
-    this_feature-adapters-split_io (0.7.0)
+    this_feature-adapters-split_io (0.7.1)
       splitclient-rb
       this_feature
 
@@ -33,7 +33,7 @@ GEM
       activerecord
       database_cleaner (~> 1.8.0)
     diff-lcs (1.3)
-    faraday (1.5.0)
+    faraday (1.7.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
       faraday-excon (~> 1.1)
@@ -41,6 +41,7 @@ GEM
       faraday-net_http (~> 1.0)
       faraday-net_http_persistent (~> 1.1)
       faraday-patron (~> 1.0)
+      faraday-rack (~> 1.0)
       multipart-post (>= 1.2, < 3)
       ruby2_keywords (>= 0.0.4)
     faraday-em_http (1.0.0)
@@ -48,12 +49,13 @@ GEM
     faraday-excon (1.1.0)
     faraday-httpclient (1.0.1)
     faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.1.0)
+    faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
-    flipper (0.22.0)
-    flipper-active_record (0.22.0)
+    faraday-rack (1.0.0)
+    flipper (0.22.1)
+    flipper-active_record (0.22.1)
       activerecord (>= 4.2, < 7)
-      flipper (~> 0.22.0)
+      flipper (~> 0.22.1)
     gem-release (2.2.1)
     hitimes (1.3.1)
     i18n (1.8.9)
@@ -73,7 +75,7 @@ GEM
       byebug (~> 11.0)
       pry (~> 0.13.0)
     rake (13.0.1)
-    redis (4.3.1)
+    redis (4.4.0)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
       rspec-expectations (~> 3.9.0)
@@ -87,10 +89,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.9.0)
     rspec-support (3.9.2)
-    ruby2_keywords (0.0.4)
+    ruby2_keywords (0.0.5)
     socketry (0.5.1)
       hitimes (~> 1.2)
-    splitclient-rb (7.2.3)
+    splitclient-rb (7.3.1)
       concurrent-ruby (~> 1.0)
       faraday (>= 0.8)
       json (>= 1.8)
@@ -122,4 +124,4 @@ DEPENDENCIES
   this_feature-adapters-split_io!
 
 BUNDLED WITH
-   2.1.4
+   2.2.25

--- a/lib/this_feature/adapters/split_io.rb
+++ b/lib/this_feature/adapters/split_io.rb
@@ -3,8 +3,9 @@ require 'splitclient-rb'
 class ThisFeature
   module Adapters
     class SplitIo < Base
-      # used as treatment key when none is given, it's required by split
-      UNDEFINED_KEY = 'undefined_key'
+      # Used as the context key when none is given. This arg is required by
+      # Split, but it's nice not to have to pass it when the context is empty.
+      EMPTY_CONTEXT = 'undefined_key'
 
       def initialize(client: nil, context_key_method: nil)
         @client = client || default_split_client
@@ -17,15 +18,15 @@ class ThisFeature
         !control?(flag_name)
       end
 
-      def control?(flag_name, context: UNDEFINED_KEY, data: {})
+      def control?(flag_name, context: EMPTY_CONTEXT, data: {})
         treatment(flag_name, context: context, data: data).include?('control')
       end
 
-      def on?(flag_name, context: UNDEFINED_KEY, data: {})
+      def on?(flag_name, context: EMPTY_CONTEXT, data: {})
         treatment(flag_name, context: context, data: data).eql?('on')
       end
 
-      def off?(flag_name, context: UNDEFINED_KEY, data: {})
+      def off?(flag_name, context: EMPTY_CONTEXT, data: {})
         treatment(flag_name, context: context, data: data).eql?('off')
       end
 
@@ -33,12 +34,12 @@ class ThisFeature
 
       attr_reader :client, :context_key_method
 
-      def treatment(flag_name, context: UNDEFINED_KEY, data: {})
+      def treatment(flag_name, context: EMPTY_CONTEXT, data: {})
         client.get_treatment(context_key(context), flag_name, data)
       end
 
       def context_key(context)
-        return UNDEFINED_KEY if context.nil? || context.eql?(UNDEFINED_KEY)
+        return EMPTY_CONTEXT if context.nil? || context.eql?(EMPTY_CONTEXT)
         return context.send(context_key_method) unless context_key_method.nil?
         return context.to_s if context.respond_to?(:to_s)
 

--- a/lib/this_feature/version.rb
+++ b/lib/this_feature/version.rb
@@ -1,3 +1,3 @@
 class ThisFeature
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end


### PR DESCRIPTION
This name change is only cosmetic, but am updating after it caused some
confusion. The flag_name always needs to be provided, but the context
does not.

We've been using 'undefined_key' for the empty context. The comment and
name are misleading, because 'treatment key' suggests it's the name of
the flag. Let's be clear this stands in for the context.