### PR TITLE
Add configuration option for base_data_lambda

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,12 @@
 PATH
   remote: .
   specs:
-    this_feature (0.7.1)
-    this_feature-adapters-flipper (0.7.1)
+    this_feature (0.8.0)
+    this_feature-adapters-flipper (0.8.0)
       flipper (~> 0.16)
       flipper-active_record (~> 0.16)
       this_feature
-    this_feature-adapters-split_io (0.7.1)
+    this_feature-adapters-split_io (0.8.0)
       splitclient-rb
       this_feature
 

--- a/docs/splitio.md
+++ b/docs/splitio.md
@@ -33,3 +33,30 @@ The SplitIo adapter supports the public API of `ThisFeature`.
 Both `context` and `data` are supported.
 
 `control` is a native Split feature, so we perform a query to Split to get this info.
+
+We've also added `record`, which is a helper to easily and consistently add
+attributes to the `data` hash. To take advantage of this, the application must
+set a `base_data_lambda` in the config. An example—
+```ruby
+ThisFeature.configure do |config|
+  config.base_data_lambda = -> (record) do
+    case record
+    when Org
+      {
+        org_id: record.id,
+        org_name: record.name
+      }
+    when User
+      {
+        org_id: record.org.id,
+        org_name: record.org.name,
+        user_email: record.email,
+        user_id: record.id,
+        user_name: record.name,
+      }
+    end
+  end
+end
+```
+Then `ThisFeature.flag("my-flag", record: user).on?` will automatically include
+org_id, org_name, user_email, user_id, and user_name in the data attributes.

--- a/lib/this_feature.rb
+++ b/lib/this_feature.rb
@@ -6,12 +6,12 @@ require 'this_feature/flag'
 
 class ThisFeature
   def self.flag(flag_name, context: nil, data: {}, record: nil)
-    adapter = adapter_for(flag_name)
+    adapter = adapter_for(flag_name, context: nil, data: {})
 
     Flag.new(flag_name, adapter: adapter, context: context, data: data, record: record)
   end
 
-  def self.adapter_for(flag_name)
+  def self.adapter_for(flag_name, context: nil, data: {})
     matching_adapter = adapters.find do |adapter|
       adapter.present?(flag_name)
     end

--- a/lib/this_feature.rb
+++ b/lib/this_feature.rb
@@ -5,13 +5,13 @@ require 'this_feature/configuration'
 require 'this_feature/flag'
 
 class ThisFeature
-  def self.flag(flag_name, context: nil, data: {})
-    adapter = adapter_for(flag_name, context: nil, data: {})
+  def self.flag(flag_name, context: nil, data: {}, record: nil)
+    adapter = adapter_for(flag_name)
 
-    Flag.new(flag_name, adapter: adapter, context: context, data: data)
+    Flag.new(flag_name, adapter: adapter, context: context, data: data, record: record)
   end
 
-  def self.adapter_for(flag_name, context: nil, data: {})
+  def self.adapter_for(flag_name)
     matching_adapter = adapters.find do |adapter|
       adapter.present?(flag_name)
     end
@@ -37,5 +37,9 @@ class ThisFeature
 
   def self.test_adapter
     configuration.test_adapter
+  end
+
+  def self.base_data_lambda
+    configuration.base_data_lambda
   end
 end

--- a/lib/this_feature/adapters/base.rb
+++ b/lib/this_feature/adapters/base.rb
@@ -5,11 +5,11 @@ class ThisFeature
         raise UnimplementedError.new(self, __method__)
       end
 
-      def on?(flag_name, context: nil, data: {})
+      def on?(flag_name, context: nil, data: {}, record: nil)
         raise UnimplementedError.new(self, __method__)
       end
 
-      def off?(flag_name, context: nil, data: {})
+      def off?(flag_name, context: nil, data: {}, record: nil)
         raise UnimplementedError.new(self, __method__)
       end
 

--- a/lib/this_feature/adapters/flipper.rb
+++ b/lib/this_feature/adapters/flipper.rb
@@ -18,11 +18,11 @@ class ThisFeature
         !present?(flag_name)
       end
 
-      def on?(flag_name, context: nil, data: {})
+      def on?(flag_name, context: nil, data: {}, record: nil)
         client[flag_name].enabled?(*[context].compact)
       end
 
-      def off?(flag_name, context: nil, data: {})
+      def off?(flag_name, context: nil, data: {}, record: nil)
         !on?(flag_name, context: context)
       end
 

--- a/lib/this_feature/adapters/memory.rb
+++ b/lib/this_feature/adapters/memory.rb
@@ -14,7 +14,7 @@ class ThisFeature
         !storage[flag_name].nil?
       end
 
-      def on?(flag_name, context: nil, data: {})
+      def on?(flag_name, context: nil, data: {}, record: nil)
         return false unless present?(flag_name)
 
         flag_data = storage[flag_name]
@@ -27,7 +27,7 @@ class ThisFeature
         !!flag_data[:contexts][context_key(context)]
       end
 
-      def off?(flag_name, context: nil, data: {})
+      def off?(flag_name, context: nil, data: {}, record: nil)
         !on?(flag_name, context: context, data: data)
       end
 

--- a/lib/this_feature/adapters/split_io.rb
+++ b/lib/this_feature/adapters/split_io.rb
@@ -18,24 +18,25 @@ class ThisFeature
         !control?(flag_name)
       end
 
-      def control?(flag_name, context: EMPTY_CONTEXT, data: {})
-        treatment(flag_name, context: context, data: data).include?('control')
+      def control?(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
+        treatment(flag_name, context: context, data: data, record: record).include?('control')
       end
 
-      def on?(flag_name, context: EMPTY_CONTEXT, data: {})
-        treatment(flag_name, context: context, data: data).eql?('on')
+      def on?(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
+        treatment(flag_name, context: context, data: data, record: record).eql?('on')
       end
 
-      def off?(flag_name, context: EMPTY_CONTEXT, data: {})
-        treatment(flag_name, context: context, data: data).eql?('off')
+      def off?(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
+        treatment(flag_name, context: context, data: data, record: record).eql?('off')
       end
 
       private
 
       attr_reader :client, :context_key_method
 
-      def treatment(flag_name, context: EMPTY_CONTEXT, data: {})
-        client.get_treatment(context_key(context), flag_name, data)
+      def treatment(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
+        base_data = ThisFeature.base_data_lambda.call(record)
+        client.get_treatment(context_key(context), flag_name, base_data.merge(data))
       end
 
       def context_key(context)

--- a/lib/this_feature/adapters/split_io.rb
+++ b/lib/this_feature/adapters/split_io.rb
@@ -35,7 +35,7 @@ class ThisFeature
       attr_reader :client, :context_key_method
 
       def treatment(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
-        base_data = ThisFeature.base_data_lambda.call(record)
+        base_data = record ? ThisFeature.base_data_lambda.call(record) : {}
         client.get_treatment(context_key(context), flag_name, base_data.merge(data))
       end
 

--- a/lib/this_feature/configuration.rb
+++ b/lib/this_feature/configuration.rb
@@ -1,6 +1,6 @@
 class ThisFeature
   class Configuration
-    attr_writer :adapters, :default_adapter, :test_adapter
+    attr_writer :adapters, :default_adapter, :test_adapter, :base_data_lambda
 
     def init
       validate_adapters!
@@ -24,6 +24,10 @@ class ThisFeature
 
     def test_adapter
       @test_adapter ||= Adapters::Memory.new
+    end
+
+    def base_data_lambda
+      @base_data_lambda ||= -> (record) { {} }
     end
   end
 end

--- a/lib/this_feature/flag.rb
+++ b/lib/this_feature/flag.rb
@@ -1,24 +1,25 @@
 class ThisFeature
   class Flag
-    attr_reader :flag_name, :context, :data, :adapter
+    attr_reader :flag_name, :context, :data, :adapter, :record
 
-    def initialize(flag_name, adapter:, context: nil, data: {})
+    def initialize(flag_name, adapter:, context: nil, data: {}, record: nil)
       @flag_name = flag_name
       @adapter = adapter
       @context = context
       @data = data
+      @record = record
     end
 
     def on?
-      adapter.on?(flag_name, context: context, data: data)
+      adapter.on?(flag_name, context: context, data: data, record: record)
     end
 
     def off?
-      adapter.off?(flag_name, context: context, data: data)
+      adapter.off?(flag_name, context: context, data: data, record: record)
     end
 
     def control?
-      adapter.control?(flag_name, context: context, data: data)
+      adapter.control?(flag_name, context: context, data: data, record: record)
     end
   end
 end

--- a/lib/this_feature/version.rb
+++ b/lib/this_feature/version.rb
@@ -1,3 +1,3 @@
 class ThisFeature
-  VERSION = "0.7.1"
+  VERSION = "0.8.0"
 end

--- a/spec/this_feature/adapters/base_adapter_spec.rb
+++ b/spec/this_feature/adapters/base_adapter_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe ThisFeature::Adapters::Base do
   context "methods providing an interface for descendent classes to implement" do
     include_examples "examples for interface method", :present?, :some_flag_name
     include_examples "examples for interface method", :on?, :some_flag_name
-    include_examples "examples for interface method", :on?, :some_flag_name, context: :fake_user, data: :stuff
+    include_examples "examples for interface method", :on?, :some_flag_name, context: :fake_user, data: :stuff, record: :fake_org
     include_examples "examples for interface method", :off?, :some_flag_name
-    include_examples "examples for interface method", :off?, :some_flag_name, context: :fake_user, data: :stuff
+    include_examples "examples for interface method", :off?, :some_flag_name, context: :fake_user, data: :stuff, record: :fake_org
 
     it 'implements #control? and returns false by default' do
       expect(described_class.new.control?(:some_flag_name)).to eq(false)

--- a/spec/this_feature/flag_spec.rb
+++ b/spec/this_feature/flag_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ThisFeature::Flag do
     subject { flag.on? }
 
     before do
-      expect(fake_adapter).to receive(:on?).with(flag_name, data: data, context: context).and_return(expected_return)
+      expect(fake_adapter).to receive(:on?).with(flag_name, data: data, context: context, record: nil).and_return(expected_return)
     end
 
     it { is_expected.to be(expected_return) }
@@ -22,7 +22,7 @@ RSpec.describe ThisFeature::Flag do
     subject { flag.off? }
 
     before do
-      expect(fake_adapter).to receive(:off?).with(flag_name, data: data, context: context).and_return(expected_return)
+      expect(fake_adapter).to receive(:off?).with(flag_name, data: data, context: context, record: nil).and_return(expected_return)
     end
 
     it { is_expected.to be(expected_return) }
@@ -32,7 +32,7 @@ RSpec.describe ThisFeature::Flag do
     subject { flag.control? }
 
     before do
-      expect(fake_adapter).to receive(:control?).with(flag_name, data: data, context: context).and_return(expected_return)
+      expect(fake_adapter).to receive(:control?).with(flag_name, data: data, context: context, record: nil).and_return(expected_return)
     end
 
     it { is_expected.to be(expected_return) }


### PR DESCRIPTION
It's common for projects to want to toggle flags based a handful of attributes. For Flag A, we'll use attribute foo and for Flag B, we'll use attribute bar.

But when happens when we actually want to use attribute foo for Flag B. Right now, this requires a code change. What if instead we can just pass a record to ThisFeature and the project can specify all the common attributes we care about given that record type?

This PR makes that change. For now, it only works with the Split adapter.