### PR TITLE
Stop passing args to .adapter_for that aren't used

### DIFF
--- a/lib/this_feature.rb
+++ b/lib/this_feature.rb
@@ -6,12 +6,12 @@ require 'this_feature/flag'
 
 class ThisFeature
   def self.flag(flag_name, context: nil, data: {})
-    adapter = adapter_for(flag_name, context: nil, data: {})
+    adapter = adapter_for(flag_name)
 
     Flag.new(flag_name, adapter: adapter, context: context, data: data)
   end
 
-  def self.adapter_for(flag_name, context: nil, data: {})
+  def self.adapter_for(flag_name)
     matching_adapter = adapters.find do |adapter|
       adapter.present?(flag_name)
     end


### PR DESCRIPTION
Adding an unrelated feature, I noticed we're passing arguments to ThisFeature.adapter_for that aren't being used. So this change removes them.