### PR TITLE
[Security] Unpin dependency versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,8 @@ PATH
   specs:
     this_feature (0.8.0)
     this_feature-adapters-flipper (0.8.0)
-      flipper (~> 0.16)
-      flipper-active_record (~> 0.16)
+      flipper
+      flipper-active_record
       this_feature
     this_feature-adapters-split_io (0.8.0)
       splitclient-rb
@@ -13,17 +13,17 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activerecord (7.0.3.1)
-      activemodel (= 7.0.3.1)
-      activesupport (= 7.0.3.1)
-    activesupport (7.0.3.1)
+    activemodel (7.0.5)
+      activesupport (= 7.0.5)
+    activerecord (7.0.5)
+      activemodel (= 7.0.5)
+      activesupport (= 7.0.5)
+    activesupport (7.0.5)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    concurrent-ruby (1.1.10)
+    concurrent-ruby (1.2.2)
     connection_pool (2.2.5)
     database_cleaner (1.8.4)
     database_cleaner-active_record (1.8.0)
@@ -49,18 +49,19 @@ GEM
     faraday-net_http_persistent (1.2.0)
     faraday-patron (1.0.0)
     faraday-rack (1.0.0)
-    flipper (0.25.0)
-    flipper-active_record (0.25.0)
+    flipper (0.28.0)
+      concurrent-ruby (< 2)
+    flipper-active_record (0.28.0)
       activerecord (>= 4.2, < 8)
-      flipper (~> 0.25.0)
+      flipper (~> 0.28.0)
     gem-release (2.2.1)
     hitimes (1.3.1)
-    i18n (1.11.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     json (2.5.1)
     jwt (2.2.3)
     lru_redux (1.1.0)
-    minitest (5.16.2)
+    minitest (5.18.0)
     multipart-post (2.1.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
@@ -94,18 +95,18 @@ GEM
       thread_safe (>= 0.3)
     sqlite3 (1.4.2)
     thread_safe (0.3.6)
-    tzinfo (2.0.4)
+    tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 2.0)
+  bundler
   database_cleaner-active_record
   gem-release
-  rake (~> 13.0)
-  rspec (~> 3.0)
+  rake
+  rspec
   sqlite3
   this_feature!
   this_feature-adapters-flipper!

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -29,7 +29,7 @@ GEM
     database_cleaner-active_record (1.8.0)
       activerecord
       database_cleaner (~> 1.8.0)
-    diff-lcs (1.3)
+    diff-lcs (1.5.0)
     faraday (1.7.0)
       faraday-em_http (~> 1.0)
       faraday-em_synchrony (~> 1.0)
@@ -65,21 +65,21 @@ GEM
     multipart-post (2.1.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
-    rake (13.0.1)
+    rake (13.0.6)
     redis (4.4.0)
-    rspec (3.9.0)
-      rspec-core (~> 3.9.0)
-      rspec-expectations (~> 3.9.0)
-      rspec-mocks (~> 3.9.0)
-    rspec-core (3.9.1)
-      rspec-support (~> 3.9.1)
-    rspec-expectations (3.9.1)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.2)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-mocks (3.9.1)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.5)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.9.0)
-    rspec-support (3.9.2)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
     ruby2_keywords (0.0.5)
     socketry (0.5.1)
       hitimes (~> 1.2)
@@ -113,4 +113,4 @@ DEPENDENCIES
   this_feature-adapters-split_io!
 
 BUNDLED WITH
-   2.3.21
+   2.4.13

--- a/this_feature-adapters-flipper.gemspec
+++ b/this_feature-adapters-flipper.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_runtime_dependency "this_feature"
-  s.add_runtime_dependency "flipper", "~> 0.16"
-  s.add_runtime_dependency "flipper-active_record", "~> 0.16"
+  s.add_runtime_dependency "flipper"
+  s.add_runtime_dependency "flipper-active_record"
 end

--- a/this_feature.gemspec
+++ b/this_feature.gemspec
@@ -31,9 +31,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "bundler"
+  spec.add_development_dependency "rake"
+  spec.add_development_dependency "rspec"
   spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "database_cleaner-active_record"
   spec.add_development_dependency "gem-release"


### PR DESCRIPTION
To address a few CVEs, this PR unpins a few development and runtime dependency gems:

- flipper
- flipper-active_record
- bundler
- rake
- rspec

Then `bundle update _____` was run on each of them to get the current latest version, which resolves these Dependabot alerts:

- https://github.com/hoverinc/this_feature/security/dependabot/2
- https://github.com/hoverinc/this_feature/security/dependabot/3
- https://github.com/hoverinc/this_feature/security/dependabot/4
- https://github.com/hoverinc/this_feature/security/dependabot/5
