### PR TITLE
`get_treatment` and `get_treatment_with_config` interface for Split and Memory Adapters

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -12,6 +12,13 @@ Under the hood, the memory adapter stores data in a dictionary like so:
       User1: true,
       User2: false
     }
+  },
+  some_flag_name_with_treatments: {
+    treatment_contexts: {
+      User1: 'treatment_name_1',
+      User2: 'treatment_name_2',
+      User3: 'treatment_name_3'
+    }
   }
 }
 ```
@@ -79,6 +86,47 @@ ThisFeature.test_adapter.on!(:flag_name, context: user) # with context
 ThisFeature.test_adapter.off!(:flag_name)               # without context
 ```
 
+### **#enable_treatment!**
+
+This method is useful when you need to enable a feature flag with a treatment (or multiple treatments), and not just `"on"` and `"off"`.
+
+Usage example of these:
+
+```ruby
+# If you have configured the in-memory adapter as the default
+ThisFeature.test_adapter.enable_treatment!(:flag_name, treatment: 'treatment_name', context: user)
+```
+#### This method requires 3 arguments:
+1. `flag_name`: String or Symbol (not a named argument)
+2. `treatment`: String
+3. `context`: User or Org object
+
+Per flag name, there can only be one treatment per `context_key` (the ID of object that is provided as `context`). So multiple calls with the same `context`, but different treatment names, will be overwritten.
+
+```ruby
+ThisFeature.test_adapter.enable_treatment!('flag_a', treatment: 'treatment_1', context: user1)
+ThisFeature.test_adapter.storage # => { 'flag_a' => { :treatment_contexts => { 'User1': 'treatment_1' } } }
+
+ThisFeature.test_adapter.enable_treatment!(:flag_a, treatment: 'treatment_2', context: user1)
+ThisFeature.test_adapter.storage # => { 'flag_a' => { :treatment_contexts => { 'User1': 'treatment_2' } } }
+```
+
+### **#treatment_value**
+
+You can retrieve the flag's treatment name for a specific context.
+
+Usage example of these:
+
+```ruby
+# If you have configured the in-memory adapter as the default
+ThisFeature.test_adapter.treatment_value(:flag_name, context: user)
+```
+
+#### This method requires 2 arguments:
+1. `flag_name`: String or Symbol (not a named argument)
+2. `context`: User or Org object
+
+When the Memory storage does not contain the given flag_name or if there is no provided `context`, `"control"` is returned. This is meant to mimic what SplitIO would return in the case of no configured treatment for the given `context`.
 ### **#clear**
 
 Since the memory adapter stores flags in memory, it won't automatically get cleaned up in your tests. You can use this method to reset the memory adapter state.

--- a/lib/this_feature/adapters/memory.rb
+++ b/lib/this_feature/adapters/memory.rb
@@ -34,8 +34,6 @@ class ThisFeature
         !present?(flag_name)
       end
 
-      # def treatment_config(flag_name, context: nil, data: {}, record: nil)
-
       def treatment_value(flag_name, context: nil, data: {}, record: nil)
         return 'control' if !present?(flag_name) || context.nil?
 

--- a/lib/this_feature/adapters/memory.rb
+++ b/lib/this_feature/adapters/memory.rb
@@ -34,6 +34,28 @@ class ThisFeature
         !present?(flag_name)
       end
 
+      # def treatment_config(flag_name, context: nil, data: {}, record: nil)
+
+      def treatment_value(flag_name, context: nil, data: {}, record: nil)
+        return 'control' if !present?(flag_name) || context.nil?
+
+        flag_data = storage[flag_name][:treatment_contexts]
+        context_registered = flag_data&.key?(context_key(context))
+
+        return 'control' if !flag_data || !context_registered
+
+        flag_data ||= {}
+        flag_data[context_key(context)]
+      end
+
+      def enable_treatment!(flag_name, treatment: nil, context: nil)
+        return false if treatment.nil? || flag_name.nil? || context.nil?
+
+        storage[flag_name] ||= {}
+        storage[flag_name][:treatment_contexts] ||= {}
+        storage[flag_name][:treatment_contexts][context_key(context)] = treatment
+      end
+
       def on!(flag_name, context: nil, data: {})
         storage[flag_name] ||= {}
 

--- a/lib/this_feature/adapters/split_io.rb
+++ b/lib/this_feature/adapters/split_io.rb
@@ -30,8 +30,12 @@ class ThisFeature
         treatment(flag_name, context: context, data: data, record: record).eql?('off')
       end
 
-      def get_treatment(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
-        treatment(flag_name, context: context, data: data, record: record)
+      def treatment_value(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
+        treatment_with_config(flag_name, context: context, data: data, record: record)[:treatment]
+      end
+
+      def treatment_config(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
+        treatment_with_config(flag_name, context: context, data: data, record: record)[:config]
       end
 
       private
@@ -41,6 +45,11 @@ class ThisFeature
       def treatment(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
         base_data = record ? ThisFeature.base_data_lambda.call(record) : {}
         client.get_treatment(context_key(context), flag_name, base_data.merge(data))
+      end
+
+      def treatment_with_config(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
+        base_data = record ? ThisFeature.base_data_lambda.call(record) : {}
+        client.get_treatment_with_config(context_key(context), flag_name, base_data.merge(data))
       end
 
       def context_key(context)

--- a/lib/this_feature/adapters/split_io.rb
+++ b/lib/this_feature/adapters/split_io.rb
@@ -30,8 +30,8 @@ class ThisFeature
         treatment(flag_name, context: context, data: data, record: record).eql?('off')
       end
 
-      def get_treatment(flag_name, record: nil)
-        client.get_treatment(record, flag_name)
+      def get_treatment(flag_name, context: EMPTY_CONTEXT, data: {}, record: nil)
+        treatment(flag_name, context: context, data: data, record: record)
       end
 
       private

--- a/lib/this_feature/adapters/split_io.rb
+++ b/lib/this_feature/adapters/split_io.rb
@@ -30,6 +30,10 @@ class ThisFeature
         treatment(flag_name, context: context, data: data, record: record).eql?('off')
       end
 
+      def get_treatment(flag_name, record: nil)
+        client.get_treatment(record, flag_name)
+      end
+
       private
 
       attr_reader :client, :context_key_method

--- a/lib/this_feature/flag.rb
+++ b/lib/this_feature/flag.rb
@@ -21,5 +21,9 @@ class ThisFeature
     def control?
       adapter.control?(flag_name, context: context, data: data, record: record)
     end
+
+    def get_treatment
+      adapter.get_treatment(flag_name, record: record)
+    end
   end
 end

--- a/lib/this_feature/flag.rb
+++ b/lib/this_feature/flag.rb
@@ -23,7 +23,7 @@ class ThisFeature
     end
 
     def get_treatment
-      adapter.get_treatment(flag_name, record: record)
+      adapter.get_treatment(flag_name, context: context, data: data, record: record)
     end
   end
 end

--- a/lib/this_feature/flag.rb
+++ b/lib/this_feature/flag.rb
@@ -22,8 +22,12 @@ class ThisFeature
       adapter.control?(flag_name, context: context, data: data, record: record)
     end
 
-    def get_treatment
-      adapter.get_treatment(flag_name, context: context, data: data, record: record)
+    def treatment_value
+      adapter.treatment_value(flag_name, context: context, data: data, record: record)
+    end
+
+    def treatment_config
+      adapter.treatment_config(flag_name, context: context, data: data, record: record)
     end
   end
 end

--- a/spec/support/files/splits.yaml
+++ b/spec/support/files/splits.yaml
@@ -16,10 +16,12 @@
 - treatment_feature:
     treatment: 'v1'
     keys: '1'
-    config: {'desc': 'this applies only to when there are many treatments'}
+    config:
+      plan_id: 1
 
 - treatment_feature:
-      treatment: 'v2'
-      keys: '2'
-      config: {'desc': 'this applies only to when there are many treatments'}
+    treatment: 'v2'
+    keys: '2'
+    config:
+      plan_id: 2
 

--- a/spec/support/files/splits.yaml
+++ b/spec/support/files/splits.yaml
@@ -12,3 +12,14 @@
     treatment: 'off'
     keys:
     config: {'desc': 'this applies only to OFF treatment'}
+
+- treatment_feature:
+    treatment: 'v1'
+    keys: '1'
+    config: {'desc': 'this applies only to when there are many treatments'}
+
+- treatment_feature:
+      treatment: 'v2'
+      keys: '2'
+      config: {'desc': 'this applies only to when there are many treatments'}
+

--- a/spec/this_feature/adapters/memory_adapter_spec.rb
+++ b/spec/this_feature/adapters/memory_adapter_spec.rb
@@ -208,6 +208,75 @@ RSpec.describe ThisFeature::Adapters::Memory do
     end
   end
 
+  describe '#enable_treatment!' do
+    subject(:enable_treatment!) { adapter.enable_treatment!(flag_name, treatment: treatment, context: context) }
+
+    let(:flag_name) { 'test-flag' }
+    let(:treatment) { 'v1' }
+    let(:context) { pseudo_user }
+
+    let(:treatment2) { 'v2' }
+    let(:context2) { pseudo_user2 }
+
+    it 'configures treatment for specific context' do
+      subject
+
+      expect(adapter.treatment_value(flag_name, context: context)).to eq(treatment)
+    end
+
+    it 'allows context ids to be overwritten' do
+      subject
+
+      expect(adapter.treatment_value(flag_name, context: context)).to eq(treatment)
+
+      adapter.enable_treatment!(flag_name, treatment: treatment2, context: context)
+
+      expect(adapter.treatment_value(flag_name, context: context)).to eq(treatment2)
+    end
+
+    it 'can accumulate many treatments for different contexts ids' do
+      subject
+
+      expect(adapter.treatment_value(flag_name, context: context)).to eq(treatment)
+
+      adapter.enable_treatment!(flag_name, treatment: treatment2, context: context2)
+
+      expect(adapter.treatment_value(flag_name, context: context2)).to eq(treatment2)
+    end
+  end
+
+  describe '#treatment_value' do
+    subject(:treatment_value) { adapter.treatment_value(flag_name, context: context) }
+
+    let(:enabled_flag_name) { 'test-flag' }
+    let(:treatment) { 'v1' }
+    let(:context) { pseudo_user }
+
+    before do
+      adapter.enable_treatment!(enabled_flag_name, treatment: treatment, context: context)
+    end
+
+    context 'when flag has been enebaled with treatment' do
+      let(:flag_name) { enabled_flag_name }
+
+      it 'returns treatment name for given context' do
+        expect(subject).to eq(treatment)
+      end
+    end
+
+    context 'when given flag is not configured with a treatment' do
+      let(:flag_name) { 'no-treatment' }
+
+      it 'returns control group name for flags with no treatments' do
+        expect(subject).to eq('control')
+      end
+    end
+  end
+
+  # describe '#treatment_config' do
+  # returns nil if there is none
+  # end
+
   describe '.on!' do
     subject(:on!) { adapter.on!(flag_name) }
 

--- a/spec/this_feature/adapters/memory_adapter_spec.rb
+++ b/spec/this_feature/adapters/memory_adapter_spec.rb
@@ -273,10 +273,6 @@ RSpec.describe ThisFeature::Adapters::Memory do
     end
   end
 
-  # describe '#treatment_config' do
-  # returns nil if there is none
-  # end
-
   describe '.on!' do
     subject(:on!) { adapter.on!(flag_name) }
 

--- a/spec/this_feature/adapters/split_io_adapter_spec.rb
+++ b/spec/this_feature/adapters/split_io_adapter_spec.rb
@@ -40,9 +40,13 @@ RSpec.describe ThisFeature::Adapters::SplitIo do
 
       context 'when org id is 1' do
         it 'returns the right treatment' do
-          expect(ThisFeature.flag(flag_name).get_treatment).to eq 'control_treatment'
-          expect(ThisFeature.flag(flag_name, context: org_id).get_treatment).to eq 'v1'
-          expect(ThisFeature.flag(flag_name, context: org_id, data: { a: :b }).get_treatment).to eq 'v1'
+          expect(ThisFeature.flag(flag_name).treatment_value).to eq 'control_treatment'
+          expect(ThisFeature.flag(flag_name, context: org_id).treatment_value).to eq 'v1'
+
+          this_feature = ThisFeature.flag(flag_name, context: org_id, data: { a: :b })
+
+          expect(this_feature.treatment_value).to eq 'v1'
+          expect(JSON.parse(this_feature.treatment_config)).to eq({ 'plan_id' => 1 })
         end
       end
 
@@ -50,9 +54,13 @@ RSpec.describe ThisFeature::Adapters::SplitIo do
         let(:org_id) { 2 }
 
         it 'returns the right treatment' do
-          expect(ThisFeature.flag(flag_name).get_treatment).to eq 'control_treatment'
-          expect(ThisFeature.flag(flag_name, context: org_id).get_treatment).to eq 'v2'
-          expect(ThisFeature.flag(flag_name, context: org_id, data: { a: :b }).get_treatment).to eq 'v2'
+          expect(ThisFeature.flag(flag_name).treatment_value).to eq 'control_treatment'
+          expect(ThisFeature.flag(flag_name, context: org_id).treatment_value).to eq 'v2'
+
+          this_feature = ThisFeature.flag(flag_name, context: org_id, data: { a: :b })
+
+          expect(this_feature.treatment_value).to eq 'v2'
+          expect(JSON.parse(this_feature.treatment_config)).to eq({ 'plan_id' => 2 })
         end
       end
     end

--- a/spec/this_feature/adapters/split_io_adapter_spec.rb
+++ b/spec/this_feature/adapters/split_io_adapter_spec.rb
@@ -35,6 +35,28 @@ RSpec.describe ThisFeature::Adapters::SplitIo do
       end
     end
 
+    context 'when the flag has multiple treatments' do
+      let(:flag_name) { :treatment_feature }
+
+      context 'when org id is 1' do
+        it 'returns the right treatment' do
+          expect(ThisFeature.flag(flag_name).get_treatment).to eq 'control_treatment'
+          expect(ThisFeature.flag(flag_name, context: org_id).get_treatment).to eq 'v1'
+          expect(ThisFeature.flag(flag_name, context: org_id, data: { a: :b }).get_treatment).to eq 'v1'
+        end
+      end
+
+      context 'when org id is 2' do
+        let(:org_id) { 2 }
+
+        it 'returns the right treatment' do
+          expect(ThisFeature.flag(flag_name).get_treatment).to eq 'control_treatment'
+          expect(ThisFeature.flag(flag_name, context: org_id).get_treatment).to eq 'v2'
+          expect(ThisFeature.flag(flag_name, context: org_id, data: { a: :b }).get_treatment).to eq 'v2'
+        end
+      end
+    end
+
     context 'when turned on for specific keys' do
       let(:flag_name) { :partially_on_feature }
 


### PR DESCRIPTION
# Context 

[INS-1225](https://hoverinc.atlassian.net/browse/INS-1225)


As the Split Adapter is written currently, it's only capable of reading from Split flags the value of being `on`, `off`, or in the `control` group. But Split features can have _many_ options for treatments. We need to update the Adapters to be able to just retrieve the treatment value, if we want a fuller use of SplitIO's capabilities. 

# Changes 

- expanding the `ThisFeature::Adapters::SplitIo` interface by adding `#treatment_value` and `#treatment_config` methods, which uses SplitIO's `get_treatment_with_config` method and returns its  `config` or treatment name as `value` 
- `ThisFeature::Flag#treatment_value` method that wraps the adapter's calling of the same method
- `#treatment_value` equivalent in `ThisFeature::Adapters::Memory` so this can be used in all environments
  - for treatment values to be configured, there is also a `#enable_treatment!()` method, which is similar to `#on!` which adds to the local storage of flag configurations and their required contexts (for which User id, etc)
  - I've purposely omitted `ThisFeature::Adapters::Memory#treatment_config`, because I wanted some feedback on the `Memory#treatment_value` implementation first
- updates to README for Memory
- if my understanding is correct, this should be a non-breaking change, because it only include additions to the gem
- TODO: update version, when changes finalized



[INS-1225]: https://hoverinc.atlassian.net/browse/INS-1225?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ