### PR TITLE
Adding Memory equivalent for `treatment_config` to be used in test environment

### DIFF
--- a/docs/memory.md
+++ b/docs/memory.md
@@ -18,6 +18,10 @@ Under the hood, the memory adapter stores data in a dictionary like so:
       User1: 'treatment_name_1',
       User2: 'treatment_name_2',
       User3: 'treatment_name_3'
+    },
+    config_contexts: {
+      User1: {},
+      User2: {}
     }
   }
 }

--- a/lib/this_feature/adapters/memory.rb
+++ b/lib/this_feature/adapters/memory.rb
@@ -34,6 +34,25 @@ class ThisFeature
         !present?(flag_name)
       end
 
+      def treatment_config(flag_name, context: nil, data: {}, record: nil)
+        return if !present?(flag_name) || context.nil?
+
+        flag_data = storage[flag_name][:config_contexts]
+        context_registered = flag_data&.key?(context_key(context))
+
+        return if !flag_data || !context_registered
+
+        flag_data[context_key(context)]
+      end
+
+      def enable_config!(flag_name, config: nil, context: nil)
+        return false if config.nil? || flag_name.nil? || context.nil?
+
+        storage[flag_name] ||= {}
+        storage[flag_name][:config_contexts] ||= {}
+        storage[flag_name][:config_contexts][context_key(context)] = config
+      end
+
       def treatment_value(flag_name, context: nil, data: {}, record: nil)
         return 'control' if !present?(flag_name) || context.nil?
 
@@ -42,7 +61,6 @@ class ThisFeature
 
         return 'control' if !flag_data || !context_registered
 
-        flag_data ||= {}
         flag_data[context_key(context)]
       end
 

--- a/spec/this_feature/adapters/memory_adapter_spec.rb
+++ b/spec/this_feature/adapters/memory_adapter_spec.rb
@@ -208,6 +208,23 @@ RSpec.describe ThisFeature::Adapters::Memory do
     end
   end
 
+  describe '#enable_config!' do
+    subject(:enable_config!) { adapter.enable_config!(flag_name, config: config, context: context) }
+
+    let(:flag_name) { 'test-flag' }
+    let(:config) { { foo: 123 } }
+    let(:context) { pseudo_user }
+
+    let(:treatment2) { 'v2' }
+    let(:context2) { pseudo_user2 }
+
+    it 'registers config for specific context' do
+      subject
+
+      expect(adapter.treatment_config(flag_name, context: context)).to eq(config)
+    end
+  end
+
   describe '#enable_treatment!' do
     subject(:enable_treatment!) { adapter.enable_treatment!(flag_name, treatment: treatment, context: context) }
 
@@ -242,6 +259,34 @@ RSpec.describe ThisFeature::Adapters::Memory do
       adapter.enable_treatment!(flag_name, treatment: treatment2, context: context2)
 
       expect(adapter.treatment_value(flag_name, context: context2)).to eq(treatment2)
+    end
+  end
+
+  describe '#treatment_config' do
+    subject(:treatment_config) { adapter.treatment_config(flag_name, context: context) }
+
+    let(:enabled_flag_name) { 'test-flag' }
+    let(:config) { { bar: 456 } }
+    let(:context) { pseudo_user }
+
+    before do
+      adapter.enable_config!(enabled_flag_name, config: config, context: context)
+    end
+
+    context 'when flag has been enabled with config' do
+      let(:flag_name) { enabled_flag_name }
+
+      it 'returns treatment configs for given context' do
+        expect(subject).to eq(config)
+      end
+    end
+
+    context 'when given flag is not registered with a config' do
+      let(:flag_name) { 'no-treatment' }
+
+      it 'returns nil' do
+        expect(subject).to be_nil
+      end
     end
   end
 


### PR DESCRIPTION
Follow up to: https://github.com/hoverinc/this_feature/pull/83

In the previous PR, we added a SplitIo adapter method for retrieving Split flag's `treatments`. Another object retrievable from Split is the `config` object, a set of key value pairs that can be registered when establishing a feature. If you have Split enabled for your codebase, its configurations are most likely set up in your codebase's `splits.yaml` file, such as:

```
- feature_flag_1:
    treatment: "off"
    keys: ["1", "2"]
    config:
      desc: some description

- feature_flag_2:
    treatment: "A group"
    keys: "3"
    config:
      plan_id: 4
      account_id: 5
```

To make using this ability in your production code, as well as in your test environment, we're adding its equivalent method in the `Memory` adapter.